### PR TITLE
Optional OPENWORM_HOME variable for those that don't want to use the ~/git path.  

### DIFF
--- a/NeuroML2/analyse_ca_boyle.sh
+++ b/NeuroML2/analyse_ca_boyle.sh
@@ -1,5 +1,6 @@
 # Assumes https://github.com/OpenSourceBrain/BlueBrainProjectShowcase has been cloned in ~/git
 
 set -e
-python ~/git/BlueBrainProjectShowcase/Channelpedia/NML2ChannelAnalyse.py -temperature 34   -minV -55  -maxV 80  -duration 600  -clampBaseVoltage -55  -clampDuration 580  -stepTargetVoltage 10  -erev 50  -caConc 0.001 ca_boyle.channel.nml ca_boyle
+OPENWORM_HOME=${OPENWORM_HOME:-~/git/}
+python $OPENWORM_HOME/BlueBrainProjectShowcase/Channelpedia/NML2ChannelAnalyse.py -temperature 34   -minV -55  -maxV 80  -duration 600  -clampBaseVoltage -55  -clampDuration 580  -stepTargetVoltage 10  -erev 50  -caConc 0.001 ca_boyle.channel.nml ca_boyle
 jnml LEMS_Test_ca_boyle.xml $1

--- a/NeuroML2/analyse_k_fast.sh
+++ b/NeuroML2/analyse_k_fast.sh
@@ -1,5 +1,6 @@
 # Assumes https://github.com/OpenSourceBrain/BlueBrainProjectShowcase has been cloned in ~/git
 
 set -e
-python ~/git/BlueBrainProjectShowcase/Channelpedia/NML2ChannelAnalyse.py -temperature 34   -minV -55  -maxV 80  -duration 600  -clampBaseVoltage -55  -clampDuration 580  -stepTargetVoltage 10  -erev -55  k_fast.channel.nml k_fast
+OPENWORM_HOME=${OPENWORM_HOME:-~/git/}
+python $OPENWORM_HOME/BlueBrainProjectShowcase/Channelpedia/NML2ChannelAnalyse.py -temperature 34   -minV -55  -maxV 80  -duration 600  -clampBaseVoltage -55  -clampDuration 580  -stepTargetVoltage 10  -erev -55  k_fast.channel.nml k_fast
 jnml LEMS_Test_k_fast.xml $1

--- a/NeuroML2/analyse_k_slow.sh
+++ b/NeuroML2/analyse_k_slow.sh
@@ -1,5 +1,6 @@
 # Assumes https://github.com/OpenSourceBrain/BlueBrainProjectShowcase has been cloned in ~/git
 
 set -e
-python ~/git/BlueBrainProjectShowcase/Channelpedia/NML2ChannelAnalyse.py -temperature 34   -minV -55  -maxV 80  -duration 600  -clampBaseVoltage -55  -clampDuration 580  -stepTargetVoltage 10  -erev -55  k_slow.channel.nml k_slow
+OPENWORM_HOME=${OPENWORM_HOME:-~/git/}
+python $OPENWORM_HOME/BlueBrainProjectShowcase/Channelpedia/NML2ChannelAnalyse.py -temperature 34   -minV -55  -maxV 80  -duration 600  -clampBaseVoltage -55  -clampDuration 580  -stepTargetVoltage 10  -erev -55  k_slow.channel.nml k_slow
 jnml LEMS_Test_k_slow.xml $1


### PR DESCRIPTION
See Issue #25.  This shouldn't change the behavior for anyone that doesn't use an OPENWORM_HOME shell variable, unless they use a weird shell that doesn't support ```X=${X:-Y}``` syntax.  But for those that do code can now be checked out anywhere on disk.  